### PR TITLE
Add Github action for Conan client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,9 @@ name: Validate Conan Action
 on:
   workflow_dispatch:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   testing-action:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         shell: bash
         run: |
           conan --version | grep -q '2.15.1'
-          conan profile show -pr:a default
+          conan profile show -pr:a default | grep -q 'Build profile'
           grep -q token "$(conan config home)/audit_providers.json"
           conan config home | grep -q "conan_home"
           python --version | grep -q '3.12'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: Validate Conan Action
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  testing-action:
+    strategy:
+      fail-fast: true
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Execute checkout
+        uses: actions/checkout@v4
+
+      - name: Consume Conan Action
+        uses: ./
+        with:
+          version: '2.15.1'
+          config_urls: |
+              https://github.com/conan-io/conan-extensions.git
+              https://github.com/conan-io/conan-extensions.git
+              https://github.com/conan-io/conan-extensions.git
+          audit_token: ${{ secrets.CONAN_AUDIT_PROVIDER_TOKEN_CONANCENTER }}
+          home: ${{ github.workspace }}/conan_home
+          cache_packages: 'true'
+          python_version: '3.12'
+
+      - name: Verify action results
+        shell: bash
+        run: |
+          conan --version | grep -q '2.15.1'
+          conan audit provider list | grep -q conancenter
+          conan config home | grep -q "conan_home"
+          python --version | grep -q '3.12'
+
+      - name: Validate caching Conan packages
+        shell: bash
+        run: |
+          conan profile detect --force
+          conan install -r conancenter --requires=asio/1.32.0 --build=missing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         shell: bash
         run: |
           conan --version | grep -q '2.15.1'
-          audit provider list | grep -q token
+          grep token "$(conan config home)/audit_providers.json"
           conan config home | grep -q "conan_home"
           python --version | grep -q '3.12'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           conan --version | grep -q '2.15.1'
           conan profile show -pr:a default
-          grep token "$(conan config home)/audit_providers.json"
+          grep -q token "$(conan config home)/audit_providers.json"
           conan config home | grep -q "conan_home"
           python --version | grep -q '3.12'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         shell: bash
         run: |
           conan --version | grep -q '2.15.1'
-          conan audit provider list | grep -q conancenter
+          grep fake "$(conan config home)/audit_providers.json"
           conan config home | grep -q "conan_home"
           python --version | grep -q '3.12'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
         shell: bash
         run: |
           conan --version | grep -q '2.15.1'
+          conan profile show default
           grep token "$(conan config home)/audit_providers.json"
           conan config home | grep -q "conan_home"
           python --version | grep -q '3.12'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         shell: bash
         run: |
           conan --version | grep -q '2.15.1'
-          conan profile show -pr:a default | grep -q 'Build profile'
+          conan profile show -pr:a default | grep -q 'settings'
           grep -q token "$(conan config home)/audit_providers.json"
           conan config home | grep -q "conan_home"
           python --version | grep -q '3.12'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
               https://github.com/conan-io/conan-extensions.git
               https://github.com/conan-io/conan-extensions.git
               https://github.com/conan-io/conan-extensions.git
-          audit_token: "fakec7b2534bef256ad113757f68be21e0fd067d47eed0ee75071a02fa2fc83f7ca5token"
+          audit_token: ${{ secrets.FAKE_TOKEN }}
           home: ${{ github.workspace }}/conan_home
           cache_packages: 'true'
           python_version: '3.12'
@@ -38,7 +38,7 @@ jobs:
         shell: bash
         run: |
           conan --version | grep -q '2.15.1'
-          grep fake "$(conan config home)/audit_providers.json"
+          conan audit provider list | grep -q conancenter
           conan config home | grep -q "conan_home"
           python --version | grep -q '3.12'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
               https://github.com/conan-io/conan-extensions.git
               https://github.com/conan-io/conan-extensions.git
               https://github.com/conan-io/conan-extensions.git
-          audit_token: ${{ secrets.CONAN_AUDIT_PROVIDER_TOKEN_CONANCENTER }}
+          audit_token: "fakec7b2534bef256ad113757f68be21e0fd067d47eed0ee75071a02fa2fc83f7ca5token"
           home: ${{ github.workspace }}/conan_home
           cache_packages: 'true'
           python_version: '3.12'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         shell: bash
         run: |
           conan --version | grep -q '2.15.1'
-          conan profile show default
+          conan profile show -pr:a default
           grep token "$(conan config home)/audit_providers.json"
           conan config home | grep -q "conan_home"
           python --version | grep -q '3.12'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,5 +46,4 @@ jobs:
       - name: Validate caching Conan packages
         shell: bash
         run: |
-          conan profile detect --force
           conan install -r conancenter --requires=asio/1.32.0 --build=missing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         shell: bash
         run: |
           conan --version | grep -q '2.15.1'
-          conan audit provider list | grep -q conancenter
+          audit provider list | grep -q token
           conan config home | grep -q "conan_home"
           python --version | grep -q '3.12'
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,63 @@
+# Install Conan Action
+
+[![Validate Conan Action](https://github.com/uilianries/conan-github-action/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/uilianries/conan-github-action/actions/workflows/ci.yml)
+[![GitHub Marketplace](https://img.shields.io/badge/Marketplace-Conan%20Package%20Manager-blue.svg?colorA=24292e&colorB=0366d6&style=flat&longCache=true&logo=github)](https://github.com/marketplace/actions/conan-io-github-action)
+
+
+A GitHub Action to install and configure the Conan package manager in your workflow.
+This action provides a simple and flexible way to set up Conan with custom configurations and audit settings.
+
+## Features
+
+- 🚀 Install any version of Conan
+- ⚙️ Apply custom Conan configurations
+- 🔐 Configure audit tokens
+- 🗂️ Cache Conan packages using GitHub cache
+- 🔍 Support for custom Conan cache directory
+- 🔗 Support for multiple configuration URL
+- 🐍 Customize Python version setup
+- 💪 Cross-platform support
+- 🔄 Composite action for better reliability
+
+## Usage
+
+### Basic Usage
+
+Install Conan, authenticate to Audit server, install custom configurations:
+
+```yaml
+steps:
+  - name: Checkout code
+    uses: actions/checkout@v4
+
+  - name: Install Conan
+    uses: uilianries/conan-github-action@v1
+    with:
+      audit_token: ${{ secrets.CONAN_AUDIT_TOKEN }}
+      config_urls: |
+        https://github.com/<org>/conan-config.git
+        https://myrepo.com/conan-config.git
+
+  - name: Install Conan dependencies
+    run: conan install . --build=missing
+```
+
+## Options
+
+This Github Action offers options inputs to execute extra steps just after installing Conan.
+This is useful for installing custom configurations or applying any other setup you need.
+It's possible to customize the action using the following options:
+
+| Option           | Type    | Description                                                                                      |
+|------------------|---------|--------------------------------------------------------------------------------------------------|
+| `version`        | string  | Conan client version to be installed. By default, it's the latest version available.             |
+| `home`           | string  | A custom path to be used as Conan cache directory.                                               |
+| `audit_token`    | string  | The Conan audit token to authenticate to the Audit server with Conan.                            |
+| `config_urls`    | list    | URLs of the Git repositories containing the custom Conan configurations to be installed.         |
+| `cache_packages` | boolean | Cache all stored Conan packages, under Conan cache, using Github cache support. false by default |
+| `python_version` | string  | Python version to be used with python-setup. By default is '3.10'                                |
+
+
+## License
+
+This project is licensed under the MIT License. See the [LICENSE](LICENSE.md) file for details.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Install Conan Action
 
-[![Validate Conan Action](https://github.com/uilianries/conan-github-action/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/uilianries/conan-github-action/actions/workflows/ci.yml)
-[![GitHub Marketplace](https://img.shields.io/badge/Marketplace-Conan%20Package%20Manager-blue.svg?colorA=24292e&colorB=0366d6&style=flat&longCache=true&logo=github)](https://github.com/marketplace/actions/conan-io-github-action)
+[![Validate Conan Action](https://github.com/uilianries/conan-github-action/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/conan-io/setup-conan/actions/workflows/ci.yml)
+[![GitHub Marketplace](https://img.shields.io/badge/Marketplace-Setup%20Conan%20Client-blue.svg?colorA=24292e&colorB=0366d6&style=flat&longCache=true&logo=github)](https://github.com/marketplace/actions/setup-conan-client)
 
 
 A GitHub Action to install and configure the Conan package manager in your workflow.
@@ -9,15 +9,13 @@ This action provides a simple and flexible way to set up Conan with custom confi
 
 ## Features
 
-- 🚀 Install any version of Conan
+- 🚀 Install any version of Conan 2.x
 - ⚙️ Apply custom Conan configurations
 - 🔐 Configure audit tokens
 - 🗂️ Cache Conan packages using GitHub cache
-- 🔍 Support for custom Conan cache directory
-- 🔗 Support for multiple configuration URL
+- 🔍 Support for custom Conan home
 - 🐍 Customize Python version setup
 - 💪 Cross-platform support
-- 🔄 Composite action for better reliability
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Install Conan Action
 
-[![Validate Conan Action](https://github.com/uilianries/conan-github-action/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/conan-io/setup-conan/actions/workflows/ci.yml)
+[![Validate Conan Action](https://github.com/conan-io/setup-conan/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/conan-io/setup-conan/actions/workflows/ci.yml)
 [![GitHub Marketplace](https://img.shields.io/badge/Marketplace-Setup%20Conan%20Client-blue.svg?colorA=24292e&colorB=0366d6&style=flat&longCache=true&logo=github)](https://github.com/marketplace/actions/setup-conan-client)
 
 
@@ -29,7 +29,7 @@ steps:
     uses: actions/checkout@v4
 
   - name: Install Conan
-    uses: uilianries/conan-github-action@v1
+    uses: conan-io/setup-conan@v1
     with:
       audit_token: ${{ secrets.CONAN_AUDIT_TOKEN }}
       config_urls: |

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This action provides a simple and flexible way to set up Conan with custom confi
 
 - 🚀 Install any version of Conan 2.x
 - ⚙️ Apply custom Conan configurations
-- 🔐 Configure audit tokens
+- 🔐 Configure audit tokens for dependencies vulnerabilities scanning
 - 🗂️ Cache Conan packages using GitHub cache
 - 🔍 Support for custom Conan home
 - 🐍 Customize Python version setup

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Install Conan Action
+# Setup Conan Action Github Action
 
 [![Validate Conan Action](https://github.com/conan-io/setup-conan/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/conan-io/setup-conan/actions/workflows/ci.yml)
 [![GitHub Marketplace](https://img.shields.io/badge/Marketplace-Setup%20Conan%20Client-blue.svg?colorA=24292e&colorB=0366d6&style=flat&longCache=true&logo=github)](https://github.com/marketplace/actions/setup-conan-client)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ It's possible to customize the action using the following options:
 
 | Option           | Type    | Description                                                                                      |
 |------------------|---------|--------------------------------------------------------------------------------------------------|
-| `version`        | string  | Conan client version to be installed. By default, it's the latest version available.             |
+| `version`        | string  | Conan client version 2.x to be installed. By default, it's the latest version available.         |
 | `home`           | string  | A custom path to be used as Conan cache directory.                                               |
 | `audit_token`    | string  | The Conan audit token to authenticate to the Audit server with Conan.                            |
 | `config_urls`    | list    | URLs of the Git repositories containing the custom Conan configurations to be installed.         |

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: 'Setup Conan Client'
 description: 'A GitHub Action to install and configure the Conan client'
-author: 'Conan.io <info@conan.io>'
+author: 'Conan.io <conan@jfrog.com>'
 
 inputs:
   version:
@@ -8,7 +8,7 @@ inputs:
     required: false
     default: ''
   config_urls:
-    description: 'URLs or paths to a Conan configuration repository to be installed. Use , (comma) to separate multiple URLs'
+    description: 'URLs or paths to a Conan configuration repository to be installed. Use new lines to separate multiple URLs.'
     required: false
     default: ''
   audit_token:

--- a/action.yml
+++ b/action.yml
@@ -45,7 +45,7 @@ runs:
       with:
         python-version: ${{ inputs.python_version }}
 
-    - name: 'Get Python version'
+    - name: 'Get installed Python version'
       id: get-python-version
       shell: bash
       run: |
@@ -73,6 +73,12 @@ runs:
           pip install conan
         fi
         echo "conan-version=$(conan --version | cut -d' ' -f3)" >> $GITHUB_OUTPUT
+
+    - name: Detect Conan profile
+      shell: bash
+      id: detect-conan-profile
+      run: |
+        conan profile detect || true
 
     - name: Get Conan cache folder path
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'Conan.io GitHub Action'
+name: 'Setup Conan Client'
 description: 'A GitHub Action to install and configure the Conan client'
 author: 'Conan.io <info@conan.io>'
 

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ author: 'Conan.io <info@conan.io>'
 
 inputs:
   version:
-    description: 'Version of Conan to install'
+    description: 'Version of Conan 2.x to install'
     required: false
     default: ''
   config_urls:
@@ -62,7 +62,12 @@ runs:
       shell: bash
       id: install-conan
       run: |
-        if [ -n "${{ inputs.conan_version }}" ]; then
+        if [ -n "${{ inputs.version }}" ]; then
+          conan_version="${{ inputs.version }}"
+          if [[ "$conan_version" == 1.* ]]; then
+            echo "ERROR: Conan 1.x is not supported. Please use Conan 2.x"
+            exit 1
+          fi
           pip install conan==${{ inputs.version }}
         else
           pip install conan

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,107 @@
+name: 'Conan.io GitHub Action'
+description: 'A GitHub Action to install and configure the Conan client'
+author: 'Conan.io <info@conan.io>'
+
+inputs:
+  version:
+    description: 'Version of Conan to install'
+    required: false
+    default: ''
+  config_urls:
+    description: 'URLs or paths to a Conan configuration repository to be installed. Use , (comma) to separate multiple URLs'
+    required: false
+    default: ''
+  audit_token:
+    description: 'Conan audit token to be used for authentication'
+    required: false
+    default: ''
+  home:
+    description: 'Custom path for Conan cache directory'
+    required: false
+    default: ''
+  cache_packages:
+    description: 'Cache all Conan packages from the cache'
+    required: false
+    default: 'false'
+  python_version:
+    description: 'Python version to install'
+    required: false
+    default: '3.10'
+
+outputs:
+  conan-version:
+    description: "Conan version"
+    value: ${{ steps.install-conan.outputs.conan-version }}
+  conan-home:
+    description: "Conan cache directory"
+    value: ${{ steps.get-conan-home.outputs.conan-home }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: 'Install Python'
+      uses: actions/setup-python@v5
+      id: setup-python
+      with:
+        python-version: ${{ inputs.python_version }}
+
+    - name: 'Get Python version'
+      id: get-python-version
+      shell: bash
+      run: |
+        echo "python-version=$(python --version | cut -d' ' -f2)" >> $GITHUB_OUTPUT
+
+    - name: Set CONAN_HOME
+      if: ${{ inputs.home != '' }}
+      id: export-conan-home
+      shell: bash
+      run: |
+        echo "CONAN_HOME=${{ inputs.home }}" >> $GITHUB_ENV
+
+    - name: 'Install Conan'
+      shell: bash
+      id: install-conan
+      run: |
+        if [ -n "${{ inputs.conan_version }}" ]; then
+          pip install conan==${{ inputs.version }}
+        else
+          pip install conan
+        fi
+        echo "conan-version=$(conan --version | cut -d' ' -f3)" >> $GITHUB_OUTPUT
+
+    - name: Get Conan cache folder path
+      shell: bash
+      id: get-conan-home
+      run: echo "conan-home=$(conan config home)" >> $GITHUB_OUTPUT
+
+    - name: 'Configure Conan'
+      if: ${{ inputs.config_urls != '' }}
+      id: configure-conan
+      shell: bash
+      run: |
+        echo "${{ inputs.config_urls }}" | while read -r url; do
+        if [ ! -z "$url" ]; then
+          conan config install "$url"
+        fi
+        done
+
+    - name: 'Authenticate Audit'
+      if: ${{ inputs.audit_token != '' }}
+      id: conan-audit-authentication
+      shell: bash
+      run: |
+        conan audit provider auth conancenter --token=${{ inputs.audit_token }}
+
+    - name: Cache Conan packages
+      if: ${{ inputs.cache_packages == 'true' }}
+      uses: actions/cache@v4.2.3
+      id: cache-conan-packages
+      with:
+        path: ${{ steps.get-conan-home.outputs.conan-home }}/p
+        key: conan-${{ steps.install-conan.outputs.conan-version }}-${{ runner.os }}
+        restore-keys: |
+          conan-${{ steps.install-conan.outputs.conan-version }}-${{ runner.os }}-
+
+branding:
+  icon: 'package'
+  color: 'blue'


### PR DESCRIPTION
Add the first and initial version of Conan client Github action, which includes:

- Install any Conan version
- Can install multiple Conan configurations from different URLs
- Authenticate to Conan audit by using a token (secret)
- Cache stored Conan packages
- Install a specific Python version
- Use a different path for Conan home
