### PR TITLE
Fix CI badge on README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,9 @@ jobs:
               https://github.com/conan-io/conan-extensions.git
               https://github.com/conan-io/conan-extensions.git
               https://github.com/conan-io/conan-extensions.git
-          audit_token: ${{ secrets.FAKE_TOKEN }}
+          # This should always be set using a GitHub secret, never as a raw string in the action.
+          # This is only for testing purposes.
+          audit_token: 'fake_token'
           home: ${{ github.workspace }}/conan_home
           cache_packages: 'true'
           python_version: '3.12'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Setup Conan Action Github Action
 
-[![Validate Conan Action](https://github.com/conan-io/setup-conan/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/conan-io/setup-conan/actions/workflows/ci.yml)
+[![Validate Conan Action](https://github.com/conan-io/setup-conan/actions/workflows/ci.yml/badge.svg)](https://github.com/conan-io/setup-conan/actions/workflows/ci.yml)
 [![GitHub Marketplace](https://img.shields.io/badge/Marketplace-Setup%20Conan%20Client-blue.svg?colorA=24292e&colorB=0366d6&style=flat&longCache=true&logo=github)](https://github.com/marketplace/actions/setup-conan-client)
 
 


### PR DESCRIPTION
This badge was extracted directly from https://github.com/conan-io/setup-conan/actions/workflows/ci.yml -> ... Button -> Create status badge

