### PR TITLE
Push lockfiles usage for CI usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,23 @@ steps:
         https://myrepo.com/conan-config.git
 
   - name: Install Conan dependencies
+    run: conan install . --build=missing
+```
+
+### Using Lockfiles
+
+In order to ensure repeatability, the use of [lockfiles](https://docs.conan.io/2/tutorial/versioning/lockfiles.html#tutorial-versioning-lockfiles) on the consumer side is greatly encouraged:
+
+```yaml
+  - name: Install Conan dependencies with lockfile
     run: conan install . --lockfile=conan.lock --lockfile-partial --lockfile-out=conan.lock --build=missing
 ```
 
-In order to ensure repeatability, the use of lockfiles on the consumer side is greatly encouraged: please check the [lockfile docs](https://docs.conan.io/2/tutorial/versioning/lockfiles.html#tutorial-versioning-lockfiles) for more information.
+Lockfiles ensure that Conan will resolve the same graph in a repeatable and consistent manner - thus making sure the same versions are used across multiple systems (CI, developers, etc).
+
+Lockfiles are strict by default, that means that if there is some requires and it cannot find a matching locked reference in the lockfile, it will error and stop. For cases where it is expected that the lockfile will not be complete, as there might be new dependencies, the `--lockfile-partial` argument can be used.
+
+By default, conan install will not generate an output lockfile, but if the `--lockfile-out` argument is provided, pointing to a filename, then a lockfile will be generated from the current dependency graph. The same lockfile can be cached or stored in the repository, so that it can be used in the future.
 
 ## Options
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,10 @@ steps:
         https://myrepo.com/conan-config.git
 
   - name: Install Conan dependencies
-    run: conan install . --build=missing
+    run: conan install . --lockfile=conan.lock --lockfile-partial --lockfile-out=conan.lock --build=missing
 ```
+
+In order to ensure repeatability, the use of lockfiles on the consumer side is greatly encouraged: please check the [lockfile docs](https://docs.conan.io/2/tutorial/versioning/lockfiles.html#tutorial-versioning-lockfiles) for more information.
 
 ## Options
 


### PR DESCRIPTION
Hello!

This PR adds a note encouraging lockfile usage, as this tool is focused on CI. Plus, the default conan install line is now using lockfiles as well.
