### PR TITLE
Do not update environment when installing Python

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,7 @@ runs:
       id: setup-python
       with:
         python-version: ${{ inputs.python_version }}
+        update_environment: false
 
     - name: 'Get installed Python version'
       id: get-python-version

--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ runs:
       id: setup-python
       with:
         python-version: ${{ inputs.python_version }}
-        update_environment: false
+        update-environment: false
 
     - name: 'Get installed Python version'
       id: get-python-version


### PR DESCRIPTION
Related to https://github.com/conan-io/conan-center-index/issues/27438

I created the repository https://github.com/uilianries/gha-conan-setup-validate to reproduce the reported bug. The setup-python action installs not only python, but also update the environment variable, including PKG_CONFIG_PATH, using an installed version from itself.

This PR avoids updating the environment, keeping only the Conan pkgconfig package in usage and avoiding any misconfiguration;