### PR TITLE
Use Conan profile settings as GHA cache key

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -79,11 +79,11 @@ runs:
       id: conan-profile
       run: |
         conan profile detect || true
-        echo "conan-arch=$(conan profile show -pr:h default -cx host --format=json | jq .host.settings.arch)" >> $GITHUB_OUTPUT
-        echo "conan-os=$(conan profile show -pr:h default -cx host --format=json | jq .host.settings.os)" >> $GITHUB_OUTPUT
-        echo "conan-compiler=$(conan profile show -pr:h default -cx host --format=json | jq .host.settings.compiler )" >> $GITHUB_OUTPUT
-        echo "conan-compiler-ver=$(conan profile show -pr:h default -cx host --format=json | jq '.host.settings.\"compiler.version\"')" >> $GITHUB_OUTPUT
-        echo "conan-build-type=$(conan profile show -pr:h default -cx host --format=json | jq .host.settings.build_type)" >> $GITHUB_OUTPUT
+        echo "conan-arch=$(conan profile show -pr:h default -cx host --format=json | jq -r .host.settings.arch)" >> $GITHUB_OUTPUT
+        echo "conan-os=$(conan profile show -pr:h default -cx host --format=json | jq -r .host.settings.os)" >> $GITHUB_OUTPUT
+        echo "conan-compiler=$(conan profile show -pr:h default -cx host --format=json | jq -r .host.settings.compiler )" >> $GITHUB_OUTPUT
+        echo "conan-compiler-ver=$(conan profile show -pr:h default -cx host --format=json | jq -r '.host.settings."compiler.version"')" >> $GITHUB_OUTPUT
+        echo "conan-build-type=$(conan profile show -pr:h default -cx host --format=json | jq -r .host.settings.build_type)" >> $GITHUB_OUTPUT
 
     - name: Get Conan cache folder path
       shell: bash


### PR DESCRIPTION
Hello! This PR is a proposal that needs further discussion, but it tries to exemplify the limitation of the GHA cache when storing the Conan cache. Plus, this PR is related to issue #6 

As commented in the issue, when having multiple CI jobs running in the same build, and the GHA cache key matches between those builds, only the first finished build will store its cache. As a consequence, a second build will not have cached packages for all jobs.

The GHA Cache has no way to update its cache, as it's [immutable](https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache), so we would need a separate cache for each job, or at least, for each configuration. 

Exposing the GHA Cache as a new option will work for users, but still does not solve the general case, as people will need to configure it almost always. 

This PR tries to isolate the GHA cache based on the Conan settings present in the profile, at least, different Ubuntu distros offered by GHA will not collide and have their own cache, avoiding missing packages in a second build wave. 

For instance, a build in Ubuntu 24.04 will result in `conan-Linux-x86_64-gcc-13-Release`. Still, there are gaps in case someone installs a different compiler or uses a second profile, but this approach should cover the general build case. 