### PR TITLE
Update actions/cache to v5.0.3

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -128,7 +128,7 @@ runs:
 
     - name: Cache Conan packages
       if: ${{ inputs.cache_packages == 'true' }}
-      uses: actions/cache@v4.2.3
+      uses: actions/cache@v5.0.3
       id: cache-conan-packages
       with:
         path: ${{ steps.get-conan-home.outputs.conan-home }}/p


### PR DESCRIPTION
## Summary

- Updates `actions/cache@v4.2.3` → `actions/cache@v5.0.3`
- Fixes the Node.js 20 deprecation warning that appears in CI runs
- Node.js 20 actions will be forced to Node.js 24 by default starting June 2nd, 2026

Closes #14